### PR TITLE
Archives actions

### DIFF
--- a/client/views/activities/templates.html
+++ b/client/views/activities/templates.html
@@ -29,6 +29,10 @@
                         archived <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>
                     {{ /if }}
 
+                    {{# if isTrue activityType 'restoredCard' }}
+                        sent <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a> to the board.
+                    {{ /if }}
+
                     {{# if isTrue activityType 'addBoardMember' }} 
                         added  {{ > memberName user=member.user offset='member' }} to this board.
                     {{ /if }}
@@ -109,9 +113,12 @@
                             added this card to {{ > memberName user=member.user offset='user' }}
                         {{/if}}
                     {{/if}}
-                    {{# if isTrue activityType 'archivedCard' }} 
-                        archived <a href="#" class="action-card" popOffset='membersAdd'>{{ card.title }}</a>
+                    {{# if isTrue activityType 'archivedCard' }}
+                        archived this card.
                     {{ /if }}
+                    {{# if isTrue activityType 'restoredCard' }}
+                        sent this card to the board.
+                    {{/ if }}
                 </div>
             {{/each}}
         </div>

--- a/client/views/cards/events.js
+++ b/client/views/cards/events.js
@@ -139,6 +139,18 @@ Template.WindowSidebarModule.events({
                 archived: true
             }
         });
+        event.preventDefault();
+    },
+    'click .js-unarchive-card': function(event, t) {
+        Cards.update(this.card._id, {
+            $set: {
+                archived: false
+            }
+        });
+        event.preventDefault();
+    },
+    'click .js-delete-card': function(event, t) {
+        Cards.remove(this.card._id);
 
         // redirect board
         Utils.goBoardId(this.card.board()._id);

--- a/client/views/cards/templates.html
+++ b/client/views/cards/templates.html
@@ -83,6 +83,12 @@
 
 <template name="cardDetailWindow">
     <div class="card-detail-window clearfix"> 
+        {{ #if card.archived }}
+            <div class="window-archive-banner js-archive-banner">
+                <span class="icon-lg icon-archive window-archive-banner-icon"></span>
+                <p class="window-archive-banner-text">This card is archived.</p>
+            </div>
+        {{ /if }}
         <div class="window-header clearfix"> 
             <span class="window-header-icon icon-lg icon-card"></span> 
             <div class="window-title card-detail-title non-empty inline {{ isMemberAll 'editable' '' }}"> 

--- a/client/views/cards/templates.html
+++ b/client/views/cards/templates.html
@@ -175,9 +175,18 @@
             <h3>Actions</h3> 
             <div class="clearfix">     
                 <hr> 
-                <a href="#" class="button-link js-archive-card" title="Remove the card from the board."> 
-                    <span class="icon-sm icon-archive"></span> Archive 
-                </a>  
+                {{ #if card.archived }}
+                    <a href="#" class="button-link js-unarchive-card" title="Send the card back to the board.">
+                        <span class="icon-sm icon-reopen"></span> Send to board
+                    </a>
+                        <a href="#" class="button-link negate js-delete-card" title="Delete the card and all history associated with it. It can’t be retrieved.">
+                        <span class="icon-sm icon-remove"></span> Delete
+                    </a>
+                {{ else }}
+                    <a href="#" class="button-link js-archive-card" title="Remove the card from the board.">
+                        <span class="icon-sm icon-archive"></span> Archive
+                    </a>
+                {{ /if }}
             </div> 
         </div>   
     </div>

--- a/collections/cards.js
+++ b/collections/cards.js
@@ -112,15 +112,26 @@ isServer(function() {
     });
 
     Cards.after.update(function(userId, doc, fieldNames, modifier) {
-        if (doc.archived) {
-            Activities.insert({
-                type: 'card',
-                activityType: "archivedCard",
-                boardId: doc.boardId,
-                listId: doc.listId,
-                cardId: doc._id,
-                userId: userId
-            });
+        if (_.contains(fieldNames, 'archived')) {
+            if (doc.archived) {
+                Activities.insert({
+                    type: 'card',
+                    activityType: "archivedCard",
+                    boardId: doc.boardId,
+                    listId: doc.listId,
+                    cardId: doc._id,
+                    userId: userId
+                });
+            } else {
+                Activities.insert({
+                    type: 'card',
+                    activityType: "restoredCard",
+                    boardId: doc.boardId,
+                    listId: doc.listId,
+                    cardId: doc._id,
+                    userId: userId
+                });
+            }
         }
     });
 


### PR DESCRIPTION
This PR adds two new actions for archived cards: “send back to board” and “delete”.

A lot of changes in the git diff view are related to empty spaces at the end of lines, which my text editor is configured to automatically remove on file save. Since I'm unlikely to be the only one with this configuration, I would recommend you sticking with this convention and removing trailing spaces in all files.

Still to do:
* [ ] Menu > “Archived items” is not implemented
* [ ] Delete confirmation pop-up